### PR TITLE
fix: error to get commit log

### DIFF
--- a/src/release/action.ts
+++ b/src/release/action.ts
@@ -26,8 +26,9 @@ const generateReleaseNote = async (
     return 'Initial Release';
   }
 
+  const { commit } = await api.getBranchInfo(branch);
   const { html_url, list: commitList } = await api.getCommitList(
-    branch,
+    commit.sha,
     latestTagCommitHash,
   );
   const list = isGenerateFromPr

--- a/src/service/api.ts
+++ b/src/service/api.ts
@@ -122,8 +122,7 @@ export default {
 
     if (isAllowMerge) {
       try {
-        const result = await git.mergePullRequest(number);
-        console.log('### merge result', result);
+        await git.mergePullRequest(number);
       } catch (e) {
         isMerged = false;
         console.log('merge failed --> ', e);


### PR DESCRIPTION
릴리즈 브랜치 머지 후에 커밋 로그 정보를 가져올 때에 이미 삭제된 브랜치인 경우 발생하는 오류 수정